### PR TITLE
Duration formatting fix

### DIFF
--- a/PyOrgMode.org
+++ b/PyOrgMode.org
@@ -79,8 +79,9 @@
 - Optimizations
    Class DataStructure : Trying to simplify the Reg exps
 #+end_src
-*** Authors [1/1]
+*** Authors [2/2]
 - [X] BISSON Jonathan <bissonjonathan on the googlethingy>
+- [X] KAIHOLA Antti <akaihol plus orgmode at ambitone dot com>
 ** Code
 *** License
     :PROPERTIES:
@@ -207,9 +208,15 @@
           def convert_date(self,date):
               """Used to convert dates from a different TZ"""
               return time.strptime(re.sub("\s(.*)\s"," ",date),"%Y-%m-%d %H:%M")
+          def format_duration(self,duration):
+              """Used to format durations identically to org-mode"""
+              timestr = time.strftime(self.timeformat,duration)
+              if timestr[0] == '0':
+                  return timestr[1:]
+              return timestr
           def __str__(self):
               """Outputs the Clock element in text format (e.g CLOCK: [2010-11-20 Sun 19:42]--[2010-11-20 Sun 20:14] =>  0:32)"""
-              return "CLOCK: [" + time.strftime(self.dateformat,self.start) + "]--["+ time.strftime(self.dateformat,self.stop) + "] =>  "+time.strftime(self.timeformat,self.duration)+"\n"
+              return "CLOCK: [" + time.strftime(self.dateformat,self.start) + "]--["+ time.strftime(self.dateformat,self.stop) + "] =>  "+self.format_duration(self.duration)+"\n"
   
 #+end_src
 *** Class Schedule
@@ -557,5 +564,31 @@ test.save_to_file("output.org")
   output_file.root.append_clean(scheduled_elements)
   
   output_file.save_to_file("test_scheduled_output.org")
+  
+#+end_src
+*** Date and time formatting
+#+srcname: test_clock.org
+#+begin_src python :tangle test_clock.py :exports code  import PyOrgMode
+  import PyOrgMode
+  import time
+  import unittest
+  
+  
+  class TestClockElement(unittest.TestCase):
+      def test_duration_format(self):
+          """Durations are formatted identically to org-mode"""
+          clock_elem = PyOrgMode.Clock.Element('2011-03-25 06:53',
+                                               '2011-03-25 09:12',
+                                               '2:19')
+          for hour in '0', '1', '5', '10', '12', '13', '19', '23':
+              for minute in '00', '01', '29', '40', '59':
+                  orig_str = '%s:%s' % (hour, minute)
+                  orig_tuple = time.strptime(orig_str,clock_elem.timeformat)
+                  formatted_str = clock_elem.format_duration(orig_tuple)
+                  self.assertEqual(formatted_str, orig_str)
+  
+  
+  if __name__ == '__main__':
+      unittest.main()
   
 #+end_src

--- a/PyOrgMode.py
+++ b/PyOrgMode.py
@@ -93,9 +93,15 @@ class Clock(OrgPlugin):
         def convert_date(self,date):
             """Used to convert dates from a different TZ"""
             return time.strptime(re.sub("\s(.*)\s"," ",date),"%Y-%m-%d %H:%M")
+        def format_duration(self,duration):
+            """Used to format durations identically to org-mode"""
+            timestr = time.strftime(self.timeformat,duration)
+            if timestr[0] == '0':
+                return timestr[1:]
+            return timestr
         def __str__(self):
             """Outputs the Clock element in text format (e.g CLOCK: [2010-11-20 Sun 19:42]--[2010-11-20 Sun 20:14] =>  0:32)"""
-            return "CLOCK: [" + time.strftime(self.dateformat,self.start) + "]--["+ time.strftime(self.dateformat,self.stop) + "] =>  "+time.strftime(self.timeformat,self.duration)+"\n"
+            return "CLOCK: [" + time.strftime(self.dateformat,self.start) + "]--["+ time.strftime(self.dateformat,self.stop) + "] =>  "+self.format_duration(self.duration)+"\n"
 
 class Schedule(OrgPlugin):
     """Plugin for Schedule elements"""

--- a/test_clock.py
+++ b/test_clock.py
@@ -1,0 +1,22 @@
+
+import PyOrgMode
+import time
+import unittest
+
+
+class TestClockElement(unittest.TestCase):
+    def test_duration_format(self):
+        """Durations are formatted identically to org-mode"""
+        clock_elem = PyOrgMode.Clock.Element('2011-03-25 06:53',
+                                             '2011-03-25 09:12',
+                                             '2:19')
+        for hour in '0', '1', '5', '10', '12', '13', '19', '23':
+            for minute in '00', '01', '29', '40', '59':
+                orig_str = '%s:%s' % (hour, minute)
+                orig_tuple = time.strptime(orig_str,clock_elem.timeformat)
+                formatted_str = clock_elem.format_duration(orig_tuple)
+                self.assertEqual(formatted_str, orig_str)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,

PyOrgMode keeps original formatting amazinlgy well when loading and saving an org-mode file. The only quirks I found were in date/time formatting.

Org-mode uses local weekday abbreviations, and PyOrgMode does write them correctly as long as the locale is set correctly (locale.setlocale()). I can't see an easy way to auto-detect the locale an .org file was written in, so this must be left to the user to take care of.

I fixed duration formatting to omit the leading zero of the hour just like org-mode does. I verified that org-mode does not use leading zeros in the C, en-US nor fi-FI locales. It might or might not do so in other locales – I haven't verified the Elisp code.

Anyway, great stuff, hope you appreciate the patch.

Antti
