### PR TITLE
Repeating timestamps and better handling of TODO states.

### DIFF
--- a/PyOrgMode.py
+++ b/PyOrgMode.py
@@ -667,13 +667,6 @@ class OrgDataStructure(OrgElement):
                     found = True
                     plugin.done_list.remove(old_state)
         return found
-    def extract_agenda(self, start, duration, todo_list):
-        """
-        Extract an agenda of headings that are marked with TODO states. 
-        First argument is the start of the agenda, second argument is duration,
-        third argument is the list of TODO states to look for.
-        """
-        pass
     def extract_todo_list(self, todo_list=None):
         """
         Extract a list of headings with TODO states specified by the first argument.


### PR DESCRIPTION
split TODO states into OrgNode.todo_states and OrgNode.done_states,
and added method OrgDataStructure.extract_todo_list.

Repeating timestamps can now be stored with the "+4w" string saved as
an attribute.

The new class OrgTodo holds individual todo items, useful for making todo lists
and agendas.

TODO states are now output properly in OrgNode._output().

There are now two lists of todo states: todo_states and done_states. A new method
was added to OrgDataStructure (add_todo_state) that allows for adding to the latter
list.

New method OrgDataStructure.extract_todo_list returns a list of OrgTodo states.
By default it returns states listed in OrgNode.todo_states but this can be modified
by arguments. It will raise an exception if a todo state is passed that is not on
either list since these will not be extracted properly during OrgDataStructure.load_from_file().
