### PR TITLE
Fix : TODO regexp bug.

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -454,7 +454,7 @@ class OrgNode(OrgPlugin):
             for todo_keyword in self.todo_list + self.done_list:
                 re_todos += separator
                 separator = "|"
-                re_todos += todo_keyword
+                re_todos += todo_keyword + "\s+"
             re_todos += ")?\s*"
             regexp_string += re_todos
         regexp_string += "(\[.*\])?\s*(.*)$"


### PR DESCRIPTION
I parse to the "**** TODO-LIST" and print this node's heading property.
I hope result is "TODO-LIST", but actual result is "-LIST".
This patch is fixed it problem.