### PR TITLE
minor fix to current.tags regex

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -497,9 +497,12 @@ class OrgNode(OrgPlugin):
       
             # Looking for tags
             heading_without_links = re.sub(" \[(.+)\]","",heading[0][3])
-
-            matches = re.finditer(r'(?=:([\w]+):)',heading_without_links)
-            [current.tags.append(match.group(1)) for match in matches]
+            heading_without_title = re.sub(r"^(?:.+)\s+(?=:)", "", heading_without_links)
+            # if no change, there is no residual string that
+            # follows the tag grammar
+            if heading_without_links != heading_without_title:
+                matches = re.finditer(r'(?=:([\w]+):)',heading_without_title)
+                [current.tags.append(match.group(1)) for match in matches]
         else:
             self.treated = False
         return current


### PR DESCRIPTION
the regex for building `current.tags` in https://github.com/bjonnh/PyOrgMode/blob/master/PyOrgMode/PyOrgMode.py#L501

causes titles containing ":something:" to be parsed as tags. An example where this shouldn't happen is like a title marked with an ISO date in the form YYYY-mm-dd HH:MM:SS. So if you have

```org
* My title 2015-04-01 00:53:21 :tag1:tag2:
````
the parser matches `["53", "tag1", "tag2"]`

The proposed method is not the prettiest but tries to minimize changes around `heading_without_links`

also see
- http://article.gmane.org/gmane.emacs.orgmode/67871 (org syntax draft)
- https://github.com/daitangio/org-mode-parser/blob/master/lib/org-mode-parser.js#L334 (another regex method for header/tag parsing)

Thanks for your work!