### PR TITLE
updated readme to give basic instructions on how to create org objects.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,12 +1,94 @@
 #+BABEL: :comments no
 #+VERSION: 0.03a
- 
+
 * PyOrgMode
-PyOrgMode is a small python library able to do simple tasks with your org files. It allows you to generate org files or treat them in an automated fashion. 
+PyOrgMode is a small python library able to do simple tasks with your org files. It allows you to generate org files or treat them in an automated fashion.
 
 This project is not my top priority, but I'm more than happy to receive pull requests. Don't worry, even if it takes some time, I go through all of them ;)
 
 I'd like to thank all the people that contributes (see AUTHORS file).
+
+** Quick Start
+
+*** Installation
+
+Download the git repo and then install the package.
+#+BEGIN_SRC sh
+git clone https://github.com/bjonnh/PyOrgMode.git
+cd PyOrgMode/
+sudo python setup.py install
+#+END_SRC
+
+*** Import an Org-Mode file
+
+Import PyOrgMode
+
+#+BEGIN_SRC python
+from PyOrgMode import PyOrgMode
+#+END_SRC
+
+Create an Org data structure to hold the org-mode file.
+
+#+BEGIN_SRC python
+base = PyOrgMode.OrgDataStructure()
+#+END_SRC
+
+Load the org-mode file.
+
+#+BEGIN_SRC python
+base.load_from_file("test.org")
+#+END_SRC
+
+*** Create an org-mode file
+Create an Org data structure to hold the org-mode file.
+#+BEGIN_SRC python
+base = PyOrgMode.OrgDataStructure()
+#+END_SRC
+
+Create a new TODO item
+#+BEGIN_SRC python
+new_todo = PyOrgMode.OrgNode.Element()
+new_todo.heading = "I am a new todo item"
+new_todo.tags=["things", "important"]
+new_todo.level = 1
+new_todo.todo = "TODO"
+#+END_SRC
+
+Add a scheduled item and a deadline to the item.
+#+BEGIN_SRC python
+_sched = PyOrgMode.OrgSchedule()
+_sched._append(new_todo, _sched.Element(scheduled="<2015-08-01 Sat 12:00-13:00>"))
+_sched._append(new_todo, _sched.Element(deadline="<2015-08-01 Sat 12:00-13:00>"))
+#+END_SRC
+
+Create a logbook drawer
+#+BEGIN_SRC python
+_props = PyOrgMode.OrgDrawer.Element("LOGBOOK")
+# Add a properties drawer
+_props.append(PyOrgMode.OrgDrawer.Element("- State \"SOMEDAY\"    from \"TODO\"     [2015-07-01 Wed 09:45]"))
+# Append the properties to the new todo item
+new_todo.append_clean(_props)
+#+END_SRC
+
+Create a properties drawer
+#+BEGIN_SRC python
+_props = PyOrgMode.OrgDrawer.Element("PROPERTIES")
+# Add a properties drawer
+_props.append(PyOrgMode.OrgDrawer.Property("FRUITS", "pineapples"))
+_props.append(PyOrgMode.OrgDrawer.Property("NAMES", "bob, sally"))
+# Append the properties to the new todo item
+new_todo.append_clean(_props)
+#+END_SRC
+
+Append the todo item to the base object
+#+BEGIN_SRC python
+base.root.append_clean(new_todo)
+#+END_SRC
+
+Save the org object to a file
+#+BEGIN_SRC python
+base.save_to_file("output.org")
+#+END_SRC
 
 ** Tools
    [[elisp:org-babel-tangle][Tangle]] (Export the files)
@@ -28,4 +110,3 @@ CodeMonk (github)
 midraal (github)
 whacked (github)
 #+end_src
-


### PR DESCRIPTION
This is a documentation pull request only. It adds basic installation instructions, basic org-mode file loading instructions, and simple instructions on how to create a simple org-mode entity within python and save it to a file.  I think this will help those who are newer to the code base to quickly pick up basic functionality.