### PR TITLE
Fix for the `extract_todo_list()` function

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -484,7 +484,7 @@ class OrgNode(OrgPlugin):
             for todo_keyword in self.todo_list + self.done_list:
                 re_todos += separator
                 separator = "|"
-                re_todos += todo_keyword + "\s+"
+                re_todos += todo_keyword
             re_todos += ")?\s*"
             regexp_string += re_todos
         regexp_string += "(\[.*?\])?\s+(.*)$"

--- a/build/lib/PyOrgMode/PyOrgMode.py
+++ b/build/lib/PyOrgMode/PyOrgMode.py
@@ -707,6 +707,7 @@ class OrgDataStructure(OrgElement):
                 except AttributeError:
                     pass
                 else: # Handle it
+                    current_todo = current_todo.rstrip()
                     if current_todo in todo_list:
                         new_todo = OrgTodo(node.heading, node.todo, tags=node.tags,priority=node.priority, node=node)
                         results_list.append(new_todo)


### PR DESCRIPTION
This pull fixes issue #31. Please note that I have only tested it on my own setup and may or may not interfere with some functions which I have not tested. I had to undo commit 880cdc2 by @10nin since it interfered with something in the code which did not match any nodes as TODOs. I also added a fix which removes the whitespace at the end of the `current_todo` variable so that the if statement below it works.

More information can be found in the commit descriptions.

I would like to know what commit 880cdc2 did exactly. I know that it changes the regular expression for finding whether a heading is a TODO item, yet I do not know what difference in made in terms of being able to output headings with dashes in them. In my own setup, I was successfully able to output headings with dashes with the following lines:

```python
print(base.root.content[2].heading)
print(base.extract_todo_list()[0].heading)
```

However, just because this works on my setup, does not exactly mean that it will work fully, so please thoroughly review it, since I'm not very familiar with this codebase.