### PR TITLE
Fix parsing of multiple tags

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -480,11 +480,11 @@ class OrgNode(OrgPlugin):
         regexp_string = "^(\*+)\s*"
         if self.todo_list:
             separator = ""
-            re_todos = "("
+            re_todos = "(" 
             for todo_keyword in self.todo_list + self.done_list:
                 re_todos += separator
                 separator = "|"
-                re_todos += todo_keyword + "\s+"
+                re_todos += todo_keyword 
             re_todos += ")?\s*"
             regexp_string += re_todos
         regexp_string += "(\[.*?\])?\s+(.*)$"
@@ -507,7 +507,8 @@ class OrgNode(OrgPlugin):
             # Creating a new node and assigning parameters
             current = OrgNode.Element() 
             current.level = len(heading[0][0])
-            current.heading = re.sub(":([\w]+):","",heading[0][3]) # Remove tags
+            current.heading = re.sub("(:\w+)*:","",heading[0][3]) # Remove tags
+            
             current.priority = heading[0][2].strip('[#]')
             current.parent = parent
             if heading[0][1]:
@@ -562,9 +563,9 @@ class OrgNode(OrgPlugin):
                     output = output + "[#" + self.priority + "] "
                 output = output + self.heading
   
-                for tag in self.tags:
-                    output= output + ":" + tag + ":"
-  
+                if self.tags:
+                    output += ':' + ':'.join(self.tags) + ':'
+                    
                 output = output + "\n"
     
             for element in self.content:

--- a/PyOrgMode/tags.org
+++ b/PyOrgMode/tags.org
@@ -1,0 +1,4 @@
+* First header                                                       :onetag:
+* TODO Second header                                          :onetag:twotag:
+* TODO Third header                                  :onetag:twotag:threetag:
+

--- a/PyOrgMode/test_tags.py
+++ b/PyOrgMode/test_tags.py
@@ -1,0 +1,51 @@
+
+"""Tests for parsing a file containing no headline
+ but that contains a bold element (thanks whacked)
+ You need the fr_FR.UTF-8 locale to run these tests
+ """
+
+import inspect
+import locale
+import PyOrgMode
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+ 
+ 
+class TestExampleOrgFile(unittest.TestCase):
+    def setUp(self):
+        self.tree = PyOrgMode.OrgDataStructure()
+        self.tree.add_todo_state('TODO')
+        self.tree.load_from_file("tags.org")
+        self.todolist = self.tree.extract_todo_list()
+        
+
+    def test_has_three_top_level_headings(self):
+        """The file has three top-level headings"""
+        self.assertEqual(len(self.tree.root.content), 3)
+
+    def test_the_first_item_has_one_tag(self):
+        node = self.tree.root.content[0]
+        self.assertEqual(len(node.tags), 1)
+        self.assertEqual(node.heading.strip(), "First header")
+        
+        
+    def test_the_second_item_has_two_tags(self):
+        """The file has three top-level headings"""
+        node = self.tree.root.content[1]
+
+        self.assertEqual(len(node.tags), 2)
+        self.assertEqual(node.tags, ["onetag", "twotag"])
+        self.assertEqual(node.heading.strip(), "Second header")
+        
+    def test_third_item_has_three_tags(self):
+        """The file has three top-level headings"""
+        node = self.tree.root.content[2]
+        self.assertEqual(len(node.tags), 3)
+        self.assertEqual(node.heading.strip(), "Third header")
+        self.assertEqual(node.output(), "* TODO Third header                                  :onetag:twotag:threetag:\n\n")
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I noticed when there are mulitple tags the header contained the tags except name. I fixed that with proper
removal of all things.


p.s. One thing I noted is that heading now contains TODO prefix - it did not in the version I got from pip. 
But I don't see any other tests for it so not sure if bug or intended behavior.