### PR TITLE
Fix bug in headline regex

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -477,7 +477,7 @@ class OrgNode(OrgPlugin):
         self.keepindent = False # If the line starts by an indent, it is not a node
     def _treat(self,current,line):
         # Build regexp
-        regexp_string = "^(\*+)\s*"
+        regexp_string = "^(\*+)\s+"
         if self.todo_list:
             separator = ""
             re_todos = "("


### PR DESCRIPTION
A valid headline needs to have at least one space after the stars; the current regex accepts headlines without a space after the stars. This PR fixes that.
