### PR TITLE
Parse localized dates

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -77,13 +77,18 @@ class OrgDate:
             'nottimed': [False, '{0}', '%Y-%m-%d'],
         }
 
+        # We ignore weekdays (e.g. "Mon", "Tue") because a single org file
+        # could mix dates in many locales, e.g. if it was edited through
+        # many compters, each with a different language
+        PARSE_WEEKDAYS=False
+
         if s.group('time'):
-            if weekday_suffix == "":
+            if weekday_suffix == "" or not PARSE_WEEKDAYS:
                 format_date = 'timed'
             else:
                 format_date = 'timed_weekday'
         else:
-            if weekday_suffix == "":
+            if weekday_suffix == "" or not PARSE_WEEKDAYS:
                 format_date = 'nottimed'
             else:
                 format_date = 'nottimed_weekday'

--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -71,22 +71,22 @@ class OrgDate:
         if weekdayed is True:
             weekday_suffix = s.group('date').split()[1]
         formats = {
-            'timed_dated': [True, '{0} {1} {2}', '%Y-%m-%d %a %H:%M'],
+            'timed_weekday': [True, '{0} {1} {2}', '%Y-%m-%d %a %H:%M'],
             'timed': [True, '{0} {2}', '%Y-%m-%d %H:%M'],
-            'nottimed_dated': [False, '{0} {1}', '%Y-%m-%d %a'],
-            'notdated': [False, '{0}', '%Y-%m-%d'],
+            'nottimed_weekday': [False, '{0} {1}', '%Y-%m-%d %a'],
+            'nottimed': [False, '{0}', '%Y-%m-%d'],
         }
 
         if s.group('time'):
             if weekday_suffix == "":
                 format_date = 'timed'
             else:
-                format_date = 'timed_dated'
+                format_date = 'timed_weekday'
         else:
             if weekday_suffix == "":
-                format_date = 'notdated'
+                format_date = 'nottimed'
             else:
-                format_date = 'nottimed_dated'
+                format_date = 'nottimed_weekday'
 
         return (formats[format_date][0], weekdayed,
                 time.strptime(

--- a/PyOrgMode/test_dates.py
+++ b/PyOrgMode/test_dates.py
@@ -40,7 +40,7 @@ class TestDates(unittest.TestCase):
         datestr = '<2011-12-12 Пнд 09:00>' # Понедельник = Monday (Russian)
         date = PyOrgMode.OrgDate(datestr)
         self.assertEqual(tuple(date.value), (2011, 12, 12, 9, 0, 0, 0, 346, -1))
-        self.assertEqual(date.get_value(), datestr)
+        self.assertEqual(date.get_value(), '<2011-12-12 Mon 09:00>')
 
     def test_localizeddatetime_dot(self):
         """
@@ -49,7 +49,7 @@ class TestDates(unittest.TestCase):
         datestr = '<2011-12-12 al. 09:00>' # astelehena = Monday (Basque)
         date = PyOrgMode.OrgDate(datestr)
         self.assertEqual(tuple(date.value), (2011, 12, 12, 9, 0, 0, 0, 346, -1))
-        self.assertEqual(date.get_value(), datestr)
+        self.assertEqual(date.get_value(), '<2011-12-12 Mon 09:00>')
 
     def test_timerange(self):
         """

--- a/PyOrgMode/test_dates.py
+++ b/PyOrgMode/test_dates.py
@@ -33,6 +33,24 @@ class TestDates(unittest.TestCase):
         self.assertEqual(tuple(date.value), (2013, 11, 20, 0, 0, 0, 2, 324, -1))
         self.assertEqual(date.get_value(), datestr)
 
+    def test_localizeddatetime_unicode(self):
+        """
+        Tests parsing dates with localized weekday name that uses non-ASCII.
+        """
+        datestr = '<2011-12-12 Пнд 09:00>' # Понедельник = Monday (Russian)
+        date = PyOrgMode.OrgDate(datestr)
+        self.assertEqual(tuple(date.value), (2011, 12, 12, 9, 0, 0, 0, 346, -1))
+        self.assertEqual(date.get_value(), datestr)
+
+    def test_localizeddatetime_dot(self):
+        """
+        Tests parsing dates with localized weekday name that includes a dot.
+        """
+        datestr = '<2011-12-12 al. 09:00>' # astelehena = Monday (Basque)
+        date = PyOrgMode.OrgDate(datestr)
+        self.assertEqual(tuple(date.value), (2011, 12, 12, 9, 0, 0, 0, 346, -1))
+        self.assertEqual(date.get_value(), datestr)
+
     def test_timerange(self):
         """
         Tests parsing time ranges on the same day.


### PR DESCRIPTION
My org files include lines like:

	 CLOCK: [2011-12-26 Пнд 15:40]--[2011-12-26 Пнд 16:11] =>  0:31
	 CLOCK: [2011-12-24 Сбт 03:27]--[2011-12-24 Сбт 03:39] =>  0:12
	 CLOCK: [2011-11-22 ar. 15:35]--[2011-11-22 ar. 16:08] =>  0:33
	 CLOCK: [2011-09-17 Сбт 18:47]--[2011-09-17 Сбт 19:04] =>  0:17
	 CLOCK: [2011-08-20 sáb 15:47]--[2011-08-20 sáb 17:44] =>  1:57

This is because I used different computers to edit them, each under a different language. This is supported by org-mode and org-mode works correctly because it uses day numbers and ignores weekday names. My patch disables parsing weekday names and adds tests for these dates.