### PR TITLE
Fix parsing for tags with "@"

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -570,7 +570,7 @@ class OrgNode(OrgPlugin):
             current = OrgNode.Element()
             current.level = len(heading[0][0])
 
-            current.heading = re.sub(":([:\w]+)*:",
+            current.heading = re.sub(":([:\w@]+)*:",
                                      "",
                                      heading[0][3])  # Remove tags
 
@@ -583,12 +583,12 @@ class OrgNode(OrgPlugin):
             heading_without_links = re.sub(" \[(.+)\]", "", heading[0][3])
             heading_without_title = re.sub(r"^(?:.+)\s+(?=:)", "",
                                            heading_without_links)
-            matches = re.finditer(r'(?=:([\w]+):)', heading_without_links)
+            matches = re.finditer(r'(?=:([\w@]+):)', heading_without_links)
             # if no change, there is no residual string that
 
             # follows the tag grammar
             if heading_without_links != heading_without_title:
-                matches = re.finditer(r'(?=:([\w]+):)',
+                matches = re.finditer(r'(?=:([\w@]+):)',
                                       heading_without_title)
                 [current.tags.append(match.group(1)) for match in matches]
         else:


### PR DESCRIPTION
This small pull request allows tags to have "@" or "_" characters as per [the tags documentation](http://orgmode.org/manual/Tags.html) on the orgmode.org website.

Not sure if you want me to add extra test cases for something like this, considering it's such a small change. However I would be happy to add them if required.