### PR TITLE
Fix a bug with tag parsing: @ was not parsed

### DIFF
--- a/PyOrgMode/PyOrgMode.py
+++ b/PyOrgMode/PyOrgMode.py
@@ -570,7 +570,7 @@ class OrgNode(OrgPlugin):
             current = OrgNode.Element()
             current.level = len(heading[0][0])
 
-            current.heading = re.sub(":([:\w]+)*:",
+            current.heading = re.sub(":([:\w@]+)*:",
                                      "",
                                      heading[0][3])  # Remove tags
 
@@ -583,12 +583,12 @@ class OrgNode(OrgPlugin):
             heading_without_links = re.sub(" \[(.+)\]", "", heading[0][3])
             heading_without_title = re.sub(r"^(?:.+)\s+(?=:)", "",
                                            heading_without_links)
-            matches = re.finditer(r'(?=:([\w]+):)', heading_without_links)
+            matches = re.finditer(r'(?=:([\w@]+):)', heading_without_links)
             # if no change, there is no residual string that
 
             # follows the tag grammar
             if heading_without_links != heading_without_title:
-                matches = re.finditer(r'(?=:([\w]+):)',
+                matches = re.finditer(r'(?=:([\w@]+):)',
                                       heading_without_title)
                 [current.tags.append(match.group(1)) for match in matches]
         else:


### PR DESCRIPTION
According to http://orgmode.org/manual/Tags.html, org tags can contain letters, numbers, _ and @.
However, according to https://www.w3schools.com/jsref/jsref_regexp_wordchar.asp, the \w that is used in the current version only recognizes letters, numbers and _.
I add the @ character to the ones parsed for tags.